### PR TITLE
Fix issue of overlap width not getting updated for subsequent menu up…

### DIFF
--- a/pushmenu.js
+++ b/pushmenu.js
@@ -45,7 +45,9 @@
           $scope.level = 0;
           $scope.visible = true;
           width = options.menuWidth || 265;
-          $element.find('nav').width(width + options.overlapWidth * wxyUtils.DepthOf($scope.menu));
+          $scope.$watch("menu",function(){
+            $element.find('nav').width(width + options.overlapWidth * wxyUtils.DepthOf($scope.menu));
+          });
           this.GetBaseWidth = function() {
             return width;
           };

--- a/src/scripts/pushmenu.coffee
+++ b/src/scripts/pushmenu.coffee
@@ -11,8 +11,9 @@ module.directive 'wxyPushMenu', ['wxyOptions', 'wxyUtils', (wxyOptions, wxyUtils
 
         # Calculate width. I don't think this is actually used anywhere right now.
         width = options.menuWidth || 265
-        $element.find('nav').width(width + options.overlapWidth * wxyUtils.DepthOf $scope.menu)
-
+        $scope.$watch("menu", ->
+            $element.find('nav').width(width + options.overlapWidth * wxyUtils.DepthOf $scope.menu)
+        )
         this.GetBaseWidth = -> width
         this.GetOptions = -> options
         return


### PR DESCRIPTION
The menu depth is not updated if the menu data is set after the initial load. Ex: If menu data are obtained from an ajax call. Fixed it by watching "menu" variable.
